### PR TITLE
add response type to result object

### DIFF
--- a/lib/remove_bg/api.rb
+++ b/lib/remove_bg/api.rb
@@ -8,6 +8,9 @@ module RemoveBg
     HEADER_API_KEY = "X-Api-Key"
     private_constant :HEADER_API_KEY
 
+    HEADER_TYPE = "X-Type"
+    private_constant :HEADER_TYPE
+
     HEADER_WIDTH = "X-Width"
     private_constant :HEADER_WIDTH
 

--- a/lib/remove_bg/api_client.rb
+++ b/lib/remove_bg/api_client.rb
@@ -51,6 +51,7 @@ module RemoveBg
     def parse_result(response)
       RemoveBg::Result.new(
         data: response.body,
+        type: response.headers[HEADER_TYPE],
         width: response.headers[HEADER_WIDTH]&.to_i,
         height: response.headers[HEADER_HEIGHT]&.to_i,
         credits_charged: response.headers[HEADER_CREDITS_CHARGED]&.to_f,

--- a/lib/remove_bg/result.rb
+++ b/lib/remove_bg/result.rb
@@ -2,10 +2,11 @@ require_relative "error"
 
 module RemoveBg
   class Result
-    attr_reader :data, :width, :height, :credits_charged
+    attr_reader :data, :type, :width, :height, :credits_charged
 
-    def initialize(data:, width:, height:, credits_charged:)
+    def initialize(data:, type:, width:, height:, credits_charged:)
       @data = data
+      @type = type
       @width = width
       @height = height
       @credits_charged = credits_charged

--- a/spec/integration/remove_from_file_spec.rb
+++ b/spec/integration/remove_from_file_spec.rb
@@ -13,6 +13,7 @@ RSpec.describe "removing the background from a file" do
 
     expect(result).to be_a RemoveBg::Result
     expect(result.data).to_not be_empty
+    expect(result.type).to eq "person"
     expect(result.height).to eq 333
     expect(result.width).to eq 500
     expect(result.credits_charged).to be_a(Float).and(be >= 0)

--- a/spec/integration/remove_from_url_spec.rb
+++ b/spec/integration/remove_from_url_spec.rb
@@ -11,6 +11,7 @@ RSpec.describe "removing the background from a URL" do
 
     expect(result).to be_a RemoveBg::Result
     expect(result.data).to_not be_empty
+    expect(result.type).to eq "person"
     expect(result.height).to eq 438
     expect(result.width).to eq 500
     expect(result.credits_charged).to be_a(Float).and(be >= 0)

--- a/spec/remove_bg/result_spec.rb
+++ b/spec/remove_bg/result_spec.rb
@@ -43,6 +43,7 @@ RSpec.describe RemoveBg::Result, "#save" do
   def new_result(data:)
     described_class.new(
       data: data,
+      type: nil,
       width: nil,
       height: nil,
       credits_charged: nil,


### PR DESCRIPTION
Hi! I add response type from headers to result object. May be need bump version to 1.2.1?