### PR TITLE
Fix compatibility with Faraday 1.x

### DIFF
--- a/Appraisals
+++ b/Appraisals
@@ -6,6 +6,6 @@ appraise "faraday-0-15" do
   gem "faraday", "~> 0.15"
 end
 
-appraise "faraday-1rc1" do
-  gem "faraday", "1.0.0.pre.rc1"
+appraise "faraday-1-x" do
+  gem "faraday", "~> 1.0"
 end

--- a/gemfiles/faraday_1_x.gemfile
+++ b/gemfiles/faraday_1_x.gemfile
@@ -2,6 +2,6 @@
 
 source "https://rubygems.org"
 
-gem "faraday", "1.0.0.pre.rc1"
+gem "faraday", "~> 1.0"
 
 gemspec path: "../"

--- a/lib/remove_bg/upload.rb
+++ b/lib/remove_bg/upload.rb
@@ -1,4 +1,4 @@
-require "faraday/upload_io"
+require "faraday"
 require_relative "error"
 
 module RemoveBg
@@ -9,7 +9,7 @@ module RemoveBg
       end
 
       content_type = determine_content_type(file_path)
-      Faraday::UploadIO.new(file_path, content_type)
+      FARADAY_FILE.new(file_path, content_type)
     end
 
     def self.determine_content_type(file_path)
@@ -22,5 +22,9 @@ module RemoveBg
     end
 
     private_class_method :determine_content_type
+
+    # UploadIO for Faraday < 0.16.0
+    FARADAY_FILE = defined?(Faraday::FilePart) ? Faraday::FilePart : Faraday::UploadIO
+    private_constant :FARADAY_FILE
   end
 end


### PR DESCRIPTION
Changes:

- Fixes missing `faraday/upload_io` require (breaking change between Faraday 1.0rc1 -> 1.0)
- Update Appraisals to test Faraday 1.x instead of rc1

Fixes: https://github.com/remove-bg/ruby/issues/6