### PR TITLE
Update minimum Faraday version

### DIFF
--- a/Appraisals
+++ b/Appraisals
@@ -1,11 +1,14 @@
-appraise "faraday-0-14" do
-  gem "faraday", "~> 0.14"
-end
-
+# Oldest supported Faraday version
 appraise "faraday-0-15" do
-  gem "faraday", "~> 0.15"
+  gem "faraday", "~> 0.15.0"
 end
 
+# Latest in Faraday 0.x series
+appraise "faraday-0-x" do
+  gem "faraday", ">= 0.15", "<= 1.0"
+end
+
+# Latest in Faraday 1.x series
 appraise "faraday-1-x" do
   gem "faraday", "~> 1.0"
 end

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -2,7 +2,7 @@ PATH
   remote: .
   specs:
     remove_bg (1.2.1)
-      faraday (>= 0.14, < 2)
+      faraday (>= 0.15, < 2)
 
 GEM
   remote: https://rubygems.org/
@@ -18,7 +18,7 @@ GEM
       safe_yaml (~> 1.0.0)
     diff-lcs (1.3)
     dotenv (2.7.1)
-    faraday (0.17.0)
+    faraday (1.0.0)
       multipart-post (>= 1.2, < 3)
     hashdiff (0.3.8)
     method_source (0.9.2)

--- a/gemfiles/faraday_0_15.gemfile
+++ b/gemfiles/faraday_0_15.gemfile
@@ -2,6 +2,6 @@
 
 source "https://rubygems.org"
 
-gem "faraday", "~> 0.15"
+gem "faraday", "~> 0.15.0"
 
 gemspec path: "../"

--- a/gemfiles/faraday_0_x.gemfile
+++ b/gemfiles/faraday_0_x.gemfile
@@ -2,6 +2,6 @@
 
 source "https://rubygems.org"
 
-gem "faraday", "~> 0.14"
+gem "faraday", ">= 0.15", "<= 1.0"
 
 gemspec path: "../"

--- a/remove_bg.gemspec
+++ b/remove_bg.gemspec
@@ -23,7 +23,7 @@ Gem::Specification.new do |spec|
   spec.executables = spec.files.grep(%r{^exe/}) { |f| File.basename(f) }
   spec.require_paths = ["lib"]
 
-  spec.add_dependency "faraday", ">= 0.14", "< 2"
+  spec.add_dependency "faraday", ">= 0.15", "< 2"
 
   spec.add_development_dependency "appraisal"
   spec.add_development_dependency "bundler", "~> 1.17"


### PR DESCRIPTION
There was a bug in our Appraisials implying tests against Faraday `0.14.x` passed. It was actually testing a later version due to the pessimistic operator missing the last digit for the patch version (it should have been `~> 0.14.0` rather than `~> 0.14`).

Unfortunately the gem has never been compatible with `0.14.x`, I suggest we raise the version to the true minimum supported version - `0.15.x` ([0.15.0](https://github.com/lostisland/faraday/releases/tag/v0.15.0) was released over 2 years ago).

Resolves: https://github.com/remove-bg/ruby/issues/3