### PR TITLE
Test Ruby 2.7 on CI

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -11,7 +11,10 @@ base_job: &base_job
 
     - run:
         name: install dependencies
-        command: bundle install --jobs=4 --retry=3 --path vendor/bundle
+        command: |
+          gem install bundler --version '~> 2.0'
+          bundle config set path vendor/bundle
+          bundle install --jobs=4 --retry=3
 
     - run:
         name: install image processsing dependencies

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -43,10 +43,6 @@ base_job: &base_job
 ################################################################################
 
 jobs:
-  ruby-2.4:
-    <<: *base_job
-    docker:
-      - image: circleci/ruby:2.4
   ruby-2.5:
     <<: *base_job
     docker:
@@ -55,6 +51,10 @@ jobs:
     <<: *base_job
     docker:
       - image: circleci/ruby:2.6
+  ruby-2.7:
+    <<: *base_job
+    docker:
+      - image: circleci/ruby:2.7
 
 ################################################################################
 
@@ -62,6 +62,6 @@ workflows:
   version: 2
   multiple-rubies:
     jobs:
-      - ruby-2.4
       - ruby-2.5
       - ruby-2.6
+      - ruby-2.7

--- a/.gitignore
+++ b/.gitignore
@@ -18,3 +18,5 @@ test-results
 gemfiles/*.gemfile.lock
 
 examples/output
+
+.ruby-version

--- a/Gemfile
+++ b/Gemfile
@@ -1,3 +1,7 @@
 source "https://rubygems.org"
 
 gemspec
+
+group :development do
+  gem "appraisal", git: "https://github.com/thoughtbot/appraisal.git", ref: "5868643"
+end

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,3 +1,13 @@
+GIT
+  remote: https://github.com/thoughtbot/appraisal.git
+  revision: 586864393e405a67b1457b563a4d5adc99e50e2d
+  ref: 5868643
+  specs:
+    appraisal (2.2.0)
+      bundler
+      rake
+      thor (>= 0.14.0)
+
 PATH
   remote: .
   specs:
@@ -11,10 +21,6 @@ GEM
   specs:
     addressable (2.7.0)
       public_suffix (>= 2.0.2, < 5.0)
-    appraisal (2.2.0)
-      bundler
-      rake
-      thor (>= 0.14.0)
     coderay (1.1.2)
     crack (0.4.3)
       safe_yaml (~> 1.0.0)
@@ -67,7 +73,7 @@ PLATFORMS
   ruby
 
 DEPENDENCIES
-  appraisal
+  appraisal!
   bundler (~> 2.0)
   dotenv
   pry

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -68,7 +68,7 @@ PLATFORMS
 
 DEPENDENCIES
   appraisal
-  bundler (~> 1.17)
+  bundler (~> 2.0)
   dotenv
   pry
   rake
@@ -80,4 +80,4 @@ DEPENDENCIES
   webmock
 
 BUNDLED WITH
-   1.17.3
+   2.1.4

--- a/gemfiles/faraday_0_15.gemfile
+++ b/gemfiles/faraday_0_15.gemfile
@@ -4,4 +4,8 @@ source "https://rubygems.org"
 
 gem "faraday", "~> 0.15.0"
 
+group :development do
+  gem "appraisal", git: "https://github.com/thoughtbot/appraisal.git", ref: "5868643"
+end
+
 gemspec path: "../"

--- a/gemfiles/faraday_0_16.gemfile
+++ b/gemfiles/faraday_0_16.gemfile
@@ -4,4 +4,8 @@ source "https://rubygems.org"
 
 gem "faraday", "~> 0.16.0"
 
+group :development do
+  gem "appraisal", git: "https://github.com/thoughtbot/appraisal.git", ref: "5868643"
+end
+
 gemspec path: "../"

--- a/gemfiles/faraday_0_17.gemfile
+++ b/gemfiles/faraday_0_17.gemfile
@@ -4,4 +4,8 @@ source "https://rubygems.org"
 
 gem "faraday", "~> 0.17.0"
 
+group :development do
+  gem "appraisal", git: "https://github.com/thoughtbot/appraisal.git", ref: "5868643"
+end
+
 gemspec path: "../"

--- a/gemfiles/faraday_1_x.gemfile
+++ b/gemfiles/faraday_1_x.gemfile
@@ -4,4 +4,8 @@ source "https://rubygems.org"
 
 gem "faraday", "~> 1.0"
 
+group :development do
+  gem "appraisal", git: "https://github.com/thoughtbot/appraisal.git", ref: "5868643"
+end
+
 gemspec path: "../"

--- a/remove_bg.gemspec
+++ b/remove_bg.gemspec
@@ -28,7 +28,7 @@ Gem::Specification.new do |spec|
   spec.add_dependency "rubyzip", ">= 2.0", "< 3"
 
   spec.add_development_dependency "appraisal"
-  spec.add_development_dependency "bundler", "~> 1.17"
+  spec.add_development_dependency "bundler", "~> 2.0"
   spec.add_development_dependency "dotenv"
   spec.add_development_dependency "pry"
   spec.add_development_dependency "rake"

--- a/remove_bg.gemspec
+++ b/remove_bg.gemspec
@@ -27,7 +27,6 @@ Gem::Specification.new do |spec|
   spec.add_dependency "image_processing", ">= 1.9", "< 2"
   spec.add_dependency "rubyzip", ">= 2.0", "< 3"
 
-  spec.add_development_dependency "appraisal"
   spec.add_development_dependency "bundler", "~> 2.0"
   spec.add_development_dependency "dotenv"
   spec.add_development_dependency "pry"


### PR DESCRIPTION
Changes:
- Test Ruby 2.7 on CI
- Drop Ruby 2.4 on CI (EOL)
- Switch to Bundler 2 for development

---

In a true tale of yak-shaving, switching to Bundler 2 requires sourcing Appraisal directly from Github to gain access to: thoughtbot/appraisal@5868643 (which fixes Appraisal with Bundler 2).

Once a new release of Appraisal is cut I'll remove this workaround.