### PR TITLE
Ensure image data stays binary / ASCII-8BIT

### DIFF
--- a/lib/remove_bg/api_client.rb
+++ b/lib/remove_bg/api_client.rb
@@ -41,6 +41,8 @@ module RemoveBg
 
     def request_remove_bg(data, api_key)
       download = Tempfile.new("remove-bg-download")
+      download.binmode
+
       streaming = false
 
       response = connection.post(V1_REMOVE_BG, data) do |req|

--- a/lib/remove_bg/composite_result.rb
+++ b/lib/remove_bg/composite_result.rb
@@ -18,18 +18,17 @@ module RemoveBg
 
     def composite_file
       @composite_file ||= begin
-        Tempfile.new(["composed", ".png"]).tap do |file|
-          compose_to_file(file)
-        end
+        binary_tempfile(["composed", ".png"])
+          .tap { |file| compose_to_file(file) }
       end
     end
 
     def color_file
-      @color_file ||= Tempfile.new(["color", ".jpg"])
+      @color_file ||= binary_tempfile(["color", ".jpg"])
     end
 
     def alpha_file
-      @alpha_file ||= Tempfile.new(["alpha", ".png"])
+      @alpha_file ||= binary_tempfile(["alpha", ".png"])
     end
 
     def compose_to_file(destination)
@@ -47,6 +46,10 @@ module RemoveBg
         zf.find_entry("color.jpg").extract(color_file.path) { true }
         zf.find_entry("alpha.png").extract(alpha_file.path) { true }
       end
+    end
+
+    def binary_tempfile(basename)
+      Tempfile.new(basename).tap { |file| file.binmode }
     end
   end
 end

--- a/spec/integration/remove_from_file_spec.rb
+++ b/spec/integration/remove_from_file_spec.rb
@@ -13,6 +13,7 @@ RSpec.describe "removing the background from a file" do
 
     expect(result).to be_a RemoveBg::Result
     expect(result.data).to_not be_empty
+    expect(result.data.encoding).to eq(Encoding::BINARY)
     expect(result.type).to eq "person"
     expect(result.height).to eq 333
     expect(result.width).to eq 500

--- a/spec/integration/remove_from_url_spec.rb
+++ b/spec/integration/remove_from_url_spec.rb
@@ -11,6 +11,7 @@ RSpec.describe "removing the background from a URL" do
 
     expect(result).to be_a RemoveBg::Result
     expect(result.data).to_not be_empty
+    expect(result.data.encoding).to eq(Encoding::BINARY)
     expect(result.type).to eq "person"
     expect(result.height).to eq 438
     expect(result.width).to eq 500

--- a/spec/integration/zip_format_spec.rb
+++ b/spec/integration/zip_format_spec.rb
@@ -18,7 +18,8 @@ RSpec.describe "using the ZIP format" do
       end
 
       expect(result).to be_a RemoveBg::CompositeResult
-      expect(result.data).to start_with("\x89PNG")
+      expect(result.data.encoding).to eq(Encoding::BINARY)
+      expect(result.data).to be_a_binary_png
       expect(result.height).to eq 333
       expect(result.width).to eq 500
     end
@@ -33,9 +34,16 @@ RSpec.describe "using the ZIP format" do
       end
 
       expect(result).to be_a RemoveBg::CompositeResult
-      expect(result.data).to start_with("\x89PNG")
+      expect(result.data.encoding).to eq(Encoding::BINARY)
+      expect(result.data).to be_a_binary_png
       expect(result.height).to eq 333
       expect(result.width).to eq 500
     end
+  end
+
+  private
+
+  def be_a_binary_png
+    start_with("\x89PNG".force_encoding(Encoding::BINARY))
   end
 end

--- a/spec/remove_bg/api_client_spec.rb
+++ b/spec/remove_bg/api_client_spec.rb
@@ -145,6 +145,22 @@ RSpec.describe RemoveBg::ApiClient do
     end
   end
 
+  describe "handling binary data" do
+    let(:image_url) { "http://example.image.jpg" }
+    let(:response_data) { "\xFF".force_encoding(Encoding::BINARY) }
+
+    it "handles the encoding correctly" do
+      stub_request(:post, %r{api.remove.bg})
+        .to_return(status: 200, body: response_data)
+
+      expect(response_data.encoding).to eq(Encoding::BINARY)
+
+      result = subject.remove_from_url(image_url, build_options)
+
+      expect(result.data.encoding).to eq(Encoding::BINARY)
+    end
+  end
+
   describe "#account_info" do
     context "with an invalid API key" do
       it "raises an error with a helpful message" do


### PR DESCRIPTION
Resolves encoding conversion issues from #14:

```
Encoding::UndefinedConversionError: "\xFF" from ASCII-8BIT to UTF-8
```

This bug was introduced in #10, when we switched to downloaded image/zip files to a tempfile. The data returned from Faraday is `ASCII-8BIT` (binary encoding) but we were writing to a file in normal mode which lead to conversion. 

This only surfaced when the data included unconvertable characters, which must only happen with certain images (none of our existing tests with fixture images had this issue).

References:
- https://www.rubydoc.info/stdlib/core/IO:binmode
- https://idiosyncratic-ruby.com/56-us-ascii-8bit.html

Resolves https://github.com/remove-bg/ruby/issues/14