### PR TITLE
Fix redefined constant warning

### DIFF
--- a/lib/remove_bg/upload.rb
+++ b/lib/remove_bg/upload.rb
@@ -24,8 +24,11 @@ module RemoveBg
 
     private_class_method :determine_content_type
 
-    FARADAY_FILE = File
-    FARADAY_FILE = Faraday::Multipart::FilePart if defined?(Faraday::Multipart::FilePart)
+    FARADAY_FILE = if defined?(Faraday::Multipart::FilePart)
+                     Faraday::Multipart::FilePart
+                   else
+                     File
+                   end.freeze
 
     private_constant :FARADAY_FILE
   end


### PR DESCRIPTION
Fix warning of redefined constant

```
ruby/lib/remove_bg/upload.rb:28: warning: already initialized constant RemoveBg::Upload::FARADAY_FILE
ruby/lib/remove_bg/upload.rb:27: warning: previous definition of FARADAY_FILE was here
```