### PR TITLE
Remove deprecated File

### DIFF
--- a/lib/remove_bg/upload.rb
+++ b/lib/remove_bg/upload.rb
@@ -10,7 +10,7 @@ module RemoveBg
       raise RemoveBg::FileMissingError.new(file_path) unless File.exist?(file_path)
 
       content_type = determine_content_type(file_path)
-      FARADAY_FILE.new(file_path, content_type)
+      Faraday::Multipart::FilePart.new(file_path, content_type)
     end
 
     def self.determine_content_type(file_path)
@@ -23,13 +23,5 @@ module RemoveBg
     end
 
     private_class_method :determine_content_type
-
-    FARADAY_FILE = if defined?(Faraday::Multipart::FilePart)
-                     Faraday::Multipart::FilePart
-                   else
-                     File
-                   end.freeze
-
-    private_constant :FARADAY_FILE
   end
 end


### PR DESCRIPTION
Since `Faraday::Multipart::FilePart` is defined in [faraday-multipart](https://rubygems.org/gems/faraday-multipart), which is now always included, the fallback to `File` can be removed.

This is especially important, because `File.new` never allowed setting the content type anyway.

```ruby
spec.add_dependency "faraday", ">= 2", "<= 3"
spec.add_dependency "faraday-multipart", "~> 1.0"
spec.add_dependency "faraday-retry", "~> 2.2"
```
